### PR TITLE
Removed PackageId tag as it's not needed

### DIFF
--- a/working/templates/nugetProject/$ProjectName$.csproj
+++ b/working/templates/nugetProject/$ProjectName$.csproj
@@ -4,7 +4,6 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<AssemblyName>$PackageId$</AssemblyName>
-		<PackageId>$PackageId$</PackageId>
 		<PackageVersion>1.0.1</PackageVersion>
 		<Version>1.0.1</Version>
 		<PackageTags>Skyline;DataMiner</PackageTags>

--- a/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
+++ b/working/templates/nugetsolution/ClassLibrary1/ClassLibrary1.csproj
@@ -4,7 +4,6 @@
 		<ImplicitUsings>disable</ImplicitUsings>
 		<Nullable>disable</Nullable>
 		<AssemblyName>$PackageId$</AssemblyName>
-		<PackageId>$PackageId$</PackageId>
 		<PackageVersion>1.0.1</PackageVersion>
 		<Version>1.0.1</Version>
 		<PackageTags>Skyline;DataMiner</PackageTags>


### PR DESCRIPTION
PackageId will take the AssemblyName when not specified: [Microsoft site](https://learn.microsoft.com/en-us/nuget/create-packages/creating-a-package-dotnet-cli#set-properties)

Removed the tag to reduce the number of items in the csproj. 
