### PR TITLE
Update $SCRIPTNAME$_1.cs

### DIFF
--- a/working/templates/userdefinedAPIsolution/$SCRIPTNAME$_1/$SCRIPTNAME$_1.cs
+++ b/working/templates/userdefinedAPIsolution/$SCRIPTNAME$_1/$SCRIPTNAME$_1.cs
@@ -21,6 +21,7 @@ namespace $NAMESPACE$_1
 			var method = requestData.RequestMethod;
 			var route = requestData.Route;
 			var body = requestData.RawBody;
+			var parameters = requestData.Parameters;
 
 			return new ApiTriggerOutput
 			{

--- a/working/templates/userdefinedAPIsolution/$SCRIPTNAME$_1/$SCRIPTNAME$_1.cs
+++ b/working/templates/userdefinedAPIsolution/$SCRIPTNAME$_1/$SCRIPTNAME$_1.cs
@@ -9,6 +9,35 @@ namespace $NAMESPACE$_1
 	/// </summary>
 	public class Script
 	{
+		private static IDictionary<string, string> GetParametersFromInput(ApiTriggerInput requestData)
+		{
+			var parameters = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+		
+			if (requestData != null)
+			{
+				var queryList = requestData.QueryParameters?.GetAllKeys();
+				if (requestData.Parameters?.Count > 0 && (queryList == null || queryList.Count == 0))
+				{
+					foreach (var parameter in requestData.Parameters)
+					{
+						parameters[parameter.Key] = parameter.Value;
+					}
+				}
+				else if (queryList?.Count > 0)
+				{
+					foreach (var query in queryList)
+					{
+						if (requestData.QueryParameters.TryGetValue(query, out var value))
+						{
+							parameters[query] = value;
+						}
+					}
+				}
+			}
+		
+			return parameters;
+		}
+		
 		/// <summary>
 		/// The API trigger.
 		/// </summary>
@@ -21,7 +50,7 @@ namespace $NAMESPACE$_1
 			var method = requestData.RequestMethod;
 			var route = requestData.Route;
 			var body = requestData.RawBody;
-			var parameters = requestData.Parameters;
+			var parameters = GetParametersFromInput(requestData);
 
 			return new ApiTriggerOutput
 			{


### PR DESCRIPTION
Add subtle declaration of query parameters. Why? to create awareness to the user that this exists as well. It is also aligned and consistent with the other parts (method, body, route). The responsebody is not expanded because it is not straight forward to pass parameters (dictionary).