### PR TITLE
Update Directory.Build.props

### DIFF
--- a/working/templates/connectorsolution/Directory.Build.props
+++ b/working/templates/connectorsolution/Directory.Build.props
@@ -6,11 +6,11 @@
 	<PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^QAction_([0-9]+)$'))">
 		<DefineConstants>$(DefineConstants);DCFv1;DBInfo;ALARM_SQUASHING</DefineConstants>
 	</PropertyGroup>
-	<PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^QAction_([0-9]+)$')) and '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+	<PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^QAction_([0-9]+)')) and '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
 		<DebugType>full</DebugType>
 		<CodeAnalysisRuleSet>..\Internal\Code Analysis\qaction-debug.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>
-	<PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^QAction_([0-9]+)$')) and '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+	<PropertyGroup Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(MSBuildProjectName), '^QAction_([0-9]+)')) and '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
 		<DebugType>pdbonly</DebugType>
 		<CodeAnalysisRuleSet>..\Internal\Code Analysis\qaction-release.ruleset</CodeAnalysisRuleSet>
 	</PropertyGroup>


### PR DESCRIPTION
DIS Feedback - StyleCop settings not applied to unit test projects. E.G. QAction_3 matches with ‘^QAction_([0-9]+)$’
while QAction_3Tests does not match. It would only match with ‘^QAction_([0-9]+)’.  (Without the ‘$’)