### PR TITLE
Ad hoc data source template - Add IGQIOptimizableDataSource life cycle interface

### DIFF
--- a/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.cs
+++ b/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.cs
@@ -15,6 +15,9 @@ namespace $NAMESPACE$
 #if (IGQIInputArguments)
 		, IGQIInputArguments
 #endif
+#if (IGQIOptimizableDataSource)
+		, IGQIOptimizableDataSource
+#endif
 #if (IGQIOnPrepareFetch)
 		, IGQIOnPrepareFetch
 #endif
@@ -56,6 +59,15 @@ namespace $NAMESPACE$
 			// See: https://aka.dataminer.services/igqidatasource-getcolumns
 			return Array.Empty<GQIColumn>();
 		}
+#if (IGQIOptimizableDataSource)
+
+		public IGQIQueryNode Optimize(IGQIDataSourceNode currentNode, IGQICoreOperator nextOperator)
+		{
+			// Inspect, optimize or customize behavior for applied operators
+			// See: https://aka.dataminer.services/igqioptimizabledatasource-optimize
+			return currentNode.Append(nextOperator);
+		}
+#endif
 #if (IGQIOnPrepareFetch)
 
 		public OnPrepareFetchOutputArgs OnPrepareFetch(OnPrepareFetchInputArgs args)

--- a/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.csproj
+++ b/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.csproj
@@ -15,7 +15,9 @@
 <!--#endif-->
 	</PropertyGroup>
 	<ItemGroup>
-<!--#if (IGQIUpdateable)-->
+<!--#if (IGQIOptimizableDataSource)-->
+		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5" />
+<!--#elseif (IGQIUpdateable)-->
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.4.4.2" />
 <!--#else-->
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.0.24" />

--- a/working/templates/gqi-ad-hoc-data-source-project/.template_config/dotnetcli.host.json
+++ b/working/templates/gqi-ad-hoc-data-source-project/.template_config/dotnetcli.host.json
@@ -11,6 +11,9 @@
     "IGQIInputArguments": {
       "shortName": "input-arguments"
     },
+    "IGQIOptimizableDataSource": {
+      "shortName": "optimizable"
+    },
     "IGQIOnPrepareFetch": {
       "shortName": "on-prepare-fetch"
     },

--- a/working/templates/gqi-ad-hoc-data-source-project/.template_config/ide.host.json
+++ b/working/templates/gqi-ad-hoc-data-source-project/.template_config/ide.host.json
@@ -1,71 +1,70 @@
 {
-    "$schema": "http://json.schemastore.org/vs-2017.3.host",
-    "order": 0,
-    "icon": "icon.png",
-    "symbolInfo": [
-      {
-        "id": "Author",
-        "name":
-        {
-          "text": "Author"
-        },
-        "isVisible": true
+  "$schema": "http://json.schemastore.org/vs-2017.3.host",
+  "order": 0,
+  "icon": "icon.png",
+  "symbolInfo": [
+    {
+      "id": "Author",
+      "name": {
+        "text": "Author"
       },
-      {
-        "id": "IGQIOnInit",
-        "name":
-        {
-          "text": "Add the IGQIOnInit interface"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIOnInit",
+      "name": {
+        "text": "Add the IGQIOnInit interface"
       },
-      {
-        "id": "IGQIInputArguments",
-        "name":
-        {
-          "text": "Add the IGQIInputArguments interface"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIInputArguments",
+      "name": {
+        "text": "Add the IGQIInputArguments interface"
       },
-      {
-        "id": "IGQIOnPrepareFetch",
-        "name":
-        {
-          "text": "Add the IGQIOnPrepareFetch interface"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIOptimizableDataSource",
+      "name": {
+        "text": "Add the IGQIOptimizableDataSource interface"
       },
-      {
-        "id": "IGQIUpdateable",
-        "name":
-        {
-          "text": "Add the IGQIUpdateable interface"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIOnPrepareFetch",
+      "name": {
+        "text": "Add the IGQIOnPrepareFetch interface"
       },
-      {
-        "id": "IGQIOnDestroy",
-        "name":
-        {
-          "text": "Add the IGQIOnDestroy interface"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIUpdateable",
+      "name": {
+        "text": "Add the IGQIUpdateable interface"
       },
-      {
-        "id": "CreateDataMinerPackage",
-        "name":
-        {
-          "text": "Create DataMiner Package"
-        },
-        "isVisible": true
+      "isVisible": true
+    },
+    {
+      "id": "IGQIOnDestroy",
+      "name": {
+        "text": "Add the IGQIOnDestroy interface"
       },
-      {
-        "id": "IncludeGitHubWorkflow",
-        "name":
-        {
-          "text": "Add GitHub CI/CD Workflow (Overwrite Existing)"
-        },
-        "isVisible": true
-      }
-    ]
+      "isVisible": true
+    },
+    {
+      "id": "CreateDataMinerPackage",
+      "name": {
+        "text": "Create DataMiner Package"
+      },
+      "isVisible": true
+    },
+    {
+      "id": "IncludeGitHubWorkflow",
+      "name": {
+        "text": "Add GitHub CI/CD Workflow (Overwrite Existing)"
+      },
+      "isVisible": true
+    }
+  ]
 }

--- a/working/templates/gqi-ad-hoc-data-source-project/.template_config/template.json
+++ b/working/templates/gqi-ad-hoc-data-source-project/.template_config/template.json
@@ -23,6 +23,11 @@
       "datatype": "bool",
       "description": "Enable arguments to pass along inputs to the data source."
     },
+    "IGQIOptimizableDataSource": {
+      "type": "parameter",
+      "datatype": "bool",
+      "description": "Optimize or customize behavior based on applied operators."
+    },
     "IGQIOnPrepareFetch": {
       "type": "parameter",
       "datatype": "bool",


### PR DESCRIPTION
Adds an additional optional life cycle interface to the ad hoc data source templates.
Available from DataMiner 10.5.5 onwards.
See also [RN42528: GQI DxM - Extensions - Allow ad hoc data sources to optimize operators](https://intranet.skyline.be/DataMiner/Lists/Release%20Notes/DispForm2.aspx?ID=42528).