### PR TITLE
Bump versions of dependencies in templates

### DIFF
--- a/working/templates/automation-library-project/$SCRIPTNAME$.csproj
+++ b/working/templates/automation-library-project/$SCRIPTNAME$.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.0.24" />
-		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.5">
+		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/working/templates/automation-project/$SCRIPTNAME$.csproj
+++ b/working/templates/automation-project/$SCRIPTNAME$.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.0.24" />
-		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.5">
+		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/working/templates/connectorsolution/QAction_1/QAction_1.csproj
+++ b/working/templates/connectorsolution/QAction_1/QAction_1.csproj
@@ -8,7 +8,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.Dev.Protocol" Version="10.3.0.24" />
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/connectorsolution/QAction_2/QAction_2.csproj
+++ b/working/templates/connectorsolution/QAction_2/QAction_2.csproj
@@ -8,8 +8,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Skyline.DataMiner.Dev.Protocol" Version="10.3.0.24" />
-    <PackageReference Include="Skyline.DataMiner.Utils.Protocol.Extension" Version="1.0.0.3" />
-    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.3">
+    <PackageReference Include="Skyline.DataMiner.Utils.Protocol.Extension" Version="1.0.0.4" />
+    <PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.csproj
+++ b/working/templates/gqi-ad-hoc-data-source-project/$SCRIPTNAME$.csproj
@@ -16,13 +16,13 @@
 	</PropertyGroup>
 	<ItemGroup>
 <!--#if (IGQIOptimizableDataSource)-->
-		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5" />
+		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.5.5.2" />
 <!--#elseif (IGQIUpdateable)-->
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.4.4.2" />
 <!--#else-->
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.0.24" />
 <!--#endif-->
-		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.5">
+		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/working/templates/package-project/$SCRIPTNAME$.csproj
+++ b/working/templates/package-project/$SCRIPTNAME$.csproj
@@ -16,9 +16,9 @@
 		<CatalogDefaultDownloadKeyName>skyline:sdk:dataminertoken</CatalogDefaultDownloadKeyName>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageReference Include="Skyline.DataMiner.Core.AppPackageInstaller" Version="2.1.0" />
+		<PackageReference Include="Skyline.DataMiner.Core.AppPackageInstaller" Version="2.1.1" />
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.0.24" />
-		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.5">
+		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/working/templates/user-defined-api-project/$SCRIPTNAME$.csproj
+++ b/working/templates/user-defined-api-project/$SCRIPTNAME$.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 	<ItemGroup>
 		<PackageReference Include="Skyline.DataMiner.Dev.Automation" Version="10.3.6" />
-		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="1.2.5">
+		<PackageReference Include="Skyline.DataMiner.Utils.SecureCoding.Analyzers" Version="2.0.1">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>


### PR DESCRIPTION
- Skyline.DataMiner.Utils.SecureCoding.Analyzers: from 1.2.5 to 2.0.1
- Skyline.DataMiner.Utils.Protocol.Extensions: from 1.0.0.3 to 1.0.0.4
- Skyline.Dataminer.Core.AppPackageInstaller: from 2.1.0 to 2.1.1

Fixed DevPack version for Ad Hoc Data Source