### PR TITLE
Connector template add support for specifying second connection.

### DIFF
--- a/working/templates/connectorsolution/.template_config/dotnetcli.host.json
+++ b/working/templates/connectorsolution/.template_config/dotnetcli.host.json
@@ -33,6 +33,10 @@
             "longName": "connection-type",
             "shortName": "ct"
         },
+        "SecondConnectionType": {
+            "longName": "second-connection-type",
+            "shortName": "sct"
+        },
 		"Author": {
             "longName": "author",
             "shortName": "auth"

--- a/working/templates/connectorsolution/.template_config/ide.host.json
+++ b/working/templates/connectorsolution/.template_config/ide.host.json
@@ -68,6 +68,14 @@
         "isVisible": true      
       },
 	  {       
+        "id": "SecondConnectionType",
+        "name": 
+        {
+          "text": "Type of the second connection"
+        },
+        "isVisible": true      
+      },
+	  {       
         "id": "Author",
         "name": 
         {

--- a/working/templates/connectorsolution/.template_config/template.json
+++ b/working/templates/connectorsolution/.template_config/template.json
@@ -77,10 +77,6 @@
           "description": "An HTTP connection."
         },
         {
-          "choice": "opc",
-          "description": "An OPC connection."
-        },
-        {
           "choice": "serial",
           "description": "A serial connection."
         },
@@ -138,10 +134,6 @@
           "description": "An HTTP connection."
         },
         {
-          "choice": "opc",
-          "description": "An OPC connection."
-        },
-        {
           "choice": "serial",
           "description": "A serial connection."
         },
@@ -193,6 +185,22 @@
       "parameters": {
         "format": "yyyy-MM-dd"
       }
+    },
+    "HasSnmpFirstConnection":{
+      "type": "computed",
+      "value": "(ConnectionType == \"snmp\" || ConnectionType == \"snmpv2\" || ConnectionType == \"snmpv3\")"
+    },
+    "HasSnmpSecondConnection":{
+      "type": "computed",
+      "value": "(SecondConnectionType == \"snmp\" || SecondConnectionType == \"snmpv2\" || SecondConnectionType == \"snmpv3\")"
+    },
+    "HasSerialFirstConnection":{
+      "type": "computed",
+      "value": "(ConnectionType == \"serial\" || ConnectionType == \"serial single\" || ConnectionType == \"smart-serial\" || ConnectionType == \"smart-serial single\")"
+    },
+    "HasSerialSecondConnection":{
+      "type": "computed",
+      "value": "(SecondConnectionType == \"serial\" || SecondConnectionType == \"serial single\" || SecondConnectionType == \"smart-serial\" || SecondConnectionType == \"smart-serial single\")"
     }
   },
   "guids": [

--- a/working/templates/connectorsolution/.template_config/template.json
+++ b/working/templates/connectorsolution/.template_config/template.json
@@ -13,126 +13,179 @@
   "sourceName": "SkylineDataMinerConnectorSolutionTemplate",
   "symbols": {
     "ConnectorName": {
-        "type": "parameter",
-        "datatype": "string",
-        "defaultValue": "Connector1",
-        "replaces": "$CONNECTORNAME$",
-        "description": "The name of the connector.",
-		"isRequired": true
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "Connector1",
+      "replaces": "$CONNECTORNAME$",
+      "description": "The name of the connector.",
+      "isRequired": true
     },
     "ProviderName": {
-        "type": "parameter",
-        "datatype": "string",
-        "defaultValue": "",
-        "replaces": "$PROVIDER$",
-        "description": "The provider name."
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "replaces": "$PROVIDER$",
+      "description": "The provider name."
     },
-	"VendorName": {
-        "type": "parameter",
-        "datatype": "string",
-        "replaces": "$VENDORNAME$",
-        "description": "The name of the vendor.",
-        "defaultValue": "",
-        "isRequired": true
+    "VendorName": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "$VENDORNAME$",
+      "description": "The name of the vendor.",
+      "defaultValue": "",
+      "isRequired": true
     },
-	"VendorOid": {
-        "type": "parameter",
-        "datatype": "string",
-        "defaultValue": "1.3.6.1.4.1.8813.2.",
-        "replaces": "$VENDOROID$",
-        "description": "The OID of the vendor.",
-        "isRequired": true
+    "VendorOid": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "1.3.6.1.4.1.8813.2.",
+      "replaces": "$VENDOROID$",
+      "description": "The OID of the vendor.",
+      "isRequired": true
     },
-	"DeviceOid": {
-        "type": "parameter",
-        "datatype": "string",
-        "replaces": "$DEVICEOID$",
-        "description": "The OID of the data source.",
-        "defaultValue": "",
-        "isRequired": true
+    "DeviceOid": {
+      "type": "parameter",
+      "datatype": "string",
+      "replaces": "$DEVICEOID$",
+      "description": "The OID of the data source.",
+      "defaultValue": "",
+      "isRequired": true
     },
-	"IntegrationId": {
-        "type": "parameter",
-        "datatype": "string",
-        "defaultValue": "DMS-DRV-",
-        "replaces": "$INTEGRATIONID$",
-        "description": "The integration ID."
+    "IntegrationId": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "DMS-DRV-",
+      "replaces": "$INTEGRATIONID$",
+      "description": "The integration ID."
     },
-	"ElementType": {
-        "type": "parameter",
-        "datatype": "string",
-        "defaultValue": "",
-        "replaces": "$ELEMENTTYPE$",
-        "description": "The element type."
+    "ElementType": {
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "replaces": "$ELEMENTTYPE$",
+      "description": "The element type."
     },
-	"ConnectionType": {
-        "type": "parameter",
-        "datatype": "choice",
-        "defaultValue": "virtual",
-        "replaces": "$CONNECTIONTYPE$",
-        "description": "The type of the main connection.",
-		    "choices": [
-							{
-							  "choice": "gpib",
-							  "description": "A GPIB connection."
-							},
-							{
-							  "choice": "http",
-							  "description": "An HTTP connection."
-							},
-							{
-							  "choice": "opc",
-							  "description": "An OPC connection."
-							},
-								{
-							  "choice": "serial",
-							  "description": "A serial connection."
-							},
-							{
-							  "choice": "serial single",
-							  "description": "A serial single connection."
-							},
-								{
-							  "choice": "service",
-							  "description": "A service."
-							},
-							{
-							  "choice": "sla",
-							  "description": "A service level agreement (SLA)."
-							},
-								{
-							  "choice": "smart-serial",
-							  "description": "A smart serial connection."
-							},
-							{
-							  "choice": "smart-serial single",
-							  "description": "A dedicated smart serial connection."
-							},
-								{
-							  "choice": "snmp",
-							  "description": "An SNMPv1 connection."
-							},
-							{
-							  "choice": "snmpv2",
-							  "description": "An SNMPv2c connection."
-							},
-								{
-							  "choice": "snmpv3",
-							  "description": "An SNMPv3 connection."
-							},
-							{
-							  "choice": "virtual",
-							  "description": "A virtual connection."
-							}
-						]
+    "ConnectionType": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "virtual",
+      "replaces": "$CONNECTIONTYPE$",
+      "description": "The type of the main connection.",
+      "choices": [
+        {
+          "choice": "http",
+          "description": "An HTTP connection."
+        },
+        {
+          "choice": "opc",
+          "description": "An OPC connection."
+        },
+        {
+          "choice": "serial",
+          "description": "A serial connection."
+        },
+        {
+          "choice": "serial single",
+          "description": "A serial single connection."
+        },
+        {
+          "choice": "service",
+          "description": "A service."
+        },
+        {
+          "choice": "sla",
+          "description": "A service level agreement (SLA)."
+        },
+        {
+          "choice": "smart-serial",
+          "description": "A smart serial connection."
+        },
+        {
+          "choice": "smart-serial single",
+          "description": "A dedicated smart serial connection."
+        },
+        {
+          "choice": "snmp",
+          "description": "An SNMPv1 connection."
+        },
+        {
+          "choice": "snmpv2",
+          "description": "An SNMPv2c connection."
+        },
+        {
+          "choice": "snmpv3",
+          "description": "An SNMPv3 connection."
+        },
+        {
+          "choice": "virtual",
+          "description": "A virtual connection."
+        }
+      ]
+    },
+    "SecondConnectionType": {
+      "type": "parameter",
+      "datatype": "choice",
+      "defaultValue": "none",
+      "replaces": "$SECONDCONNECTIONTYPE$",
+      "description": "The type of the second connection.",
+      "choices": [
+        {
+          "choice": "none",
+          "description": "No second connection."
+        },
+        {
+          "choice": "http",
+          "description": "An HTTP connection."
+        },
+        {
+          "choice": "opc",
+          "description": "An OPC connection."
+        },
+        {
+          "choice": "serial",
+          "description": "A serial connection."
+        },
+        {
+          "choice": "serial single",
+          "description": "A serial single connection."
+        },
+        {
+          "choice": "service",
+          "description": "A service."
+        },
+        {
+          "choice": "sla",
+          "description": "A service level agreement (SLA)."
+        },
+        {
+          "choice": "smart-serial",
+          "description": "A smart serial connection."
+        },
+        {
+          "choice": "smart-serial single",
+          "description": "A dedicated smart serial connection."
+        },
+        {
+          "choice": "snmp",
+          "description": "An SNMPv1 connection."
+        },
+        {
+          "choice": "snmpv2",
+          "description": "An SNMPv2c connection."
+        },
+        {
+          "choice": "snmpv3",
+          "description": "An SNMPv3 connection."
+        }
+      ]
     },
     "Author": {
-          "type": "parameter",
-          "datatype": "string",
-          "defaultValue": "",
-          "replaces": "$AUTHOR$",
-          "description": "The author."
-      },
+      "type": "parameter",
+      "datatype": "string",
+      "defaultValue": "",
+      "replaces": "$AUTHOR$",
+      "description": "The author."
+    },
     "InitialVersionDate": {
       "type": "generated",
       "generator": "now",
@@ -140,7 +193,7 @@
       "parameters": {
         "format": "yyyy-MM-dd"
       }
-	  }
+    }
   },
   "guids": [
     "1F2B2B24-15BE-4DE0-99F7-6531694672FB",

--- a/working/templates/connectorsolution/.template_config/template.json
+++ b/working/templates/connectorsolution/.template_config/template.json
@@ -233,7 +233,7 @@
       "args": {
         "files": "0"
       },
-      "continueOnError": false
+      "continueOnError": true
     }
   ]
 }

--- a/working/templates/connectorsolution/.template_config/template.json
+++ b/working/templates/connectorsolution/.template_config/template.json
@@ -217,5 +217,23 @@
         }
       ]
     }
+  ],
+  "primaryOutputs": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\")",
+      "path": "protocol.xml"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(HostIdentifier != \"dotnetcli\")",
+      "description": "Opens the protocol.xml file in the editor",
+      "manualInstructions": [],
+      "actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+      "args": {
+        "files": "0"
+      },
+      "continueOnError": false
+    }
   ]
 }

--- a/working/templates/connectorsolution/.template_config/template.json
+++ b/working/templates/connectorsolution/.template_config/template.json
@@ -73,6 +73,10 @@
       "description": "The type of the main connection.",
       "choices": [
         {
+          "choice": "gpib",
+          "description": "A GPIB connection."
+        },
+        {
           "choice": "http",
           "description": "An HTTP connection."
         },
@@ -128,6 +132,10 @@
         {
           "choice": "none",
           "description": "No second connection."
+        },
+        {
+          "choice": "gpib",
+          "description": "A GPIB connection."
         },
         {
           "choice": "http",

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -27,6 +27,8 @@
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SLA Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "service")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:Service Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "gpib")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:GPIB Connection">$CONNECTIONTYPE$</Type>
 	<!--#endif-->
 	<!--#else-->
 	<!--#if(SecondConnectionType == "http")-->
@@ -48,6 +50,9 @@
 	<!--#elseif(SecondConnectionType == "service")-->
 	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:Service Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "gpib")-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:GPIB Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#endif-->
 	<!--#endif-->
 	<!--#endif-->
@@ -176,6 +181,8 @@
 	<PortSettings name="SLA Connection" />
 	<!--#elseif(ConnectionType == "service")-->
 	<PortSettings name="Service Connection" />
+	<!--#elseif(ConnectionType == "gpib")-->
+	<PortSettings name="GPIB Connection" />
 	<!--#endif-->
 	<!--#if(SecondConnectionType != "none")-->
 
@@ -210,6 +217,8 @@
 		<PortSettings name="SLA Connection" />
 		<!--#elseif(SecondConnectionType == "service")-->
 		<PortSettings name="Service Connection" />
+		<!--#elseif(SecondConnectionType == "gpib")-->
+		<PortSettings name="GPIB Connection" />
 		<!--#endif-->
 	<!--#endif-->
 	<!--#if(ConnectionType == SecondConnectionType)-->
@@ -248,6 +257,10 @@
 		</PortSettings>
 		<!--#elseif(SecondConnectionType == "service")-->
 		<PortSettings name="Service Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "gpib")-->
+		<PortSettings name="GPIB Connection - XXX">
 		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 		</PortSettings>
 		<!--#endif-->

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -10,7 +10,11 @@
 	<DeviceOID>$DEVICEOID$</DeviceOID>
 	<SNMP includepages="true">auto</SNMP>
 	<ElementType>$ELEMENTTYPE$</ElementType>
+  <!--#if (SecondConnectionType == "none")-->
 	<Type relativeTimers="true" options=";unicode">$CONNECTIONTYPE$</Type>
+  <!--#else-->
+  <Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$">$CONNECTIONTYPE$</Type>
+  <!--#endif-->
 	<Display defaultPage="General" pageOrder="General"/>
 
 	<Compliancies>
@@ -26,6 +30,15 @@
 		</Param>
 	</Params>
 
+  <!--#if (ConnectionType == "serial" || SecondConnectionType == "serial")-->
+  <Commands>
+  </Commands>
+  <Responses>
+  </Responses>
+  <Pairs>
+  </Pairs>
+  <!--#else-->
+  <!--#endif-->
 	<QActions>
 		<QAction id="1" name="Precompiled Code" encoding="csharp" options="precompile" />
 		<QAction id="2" name="After Startup" encoding="csharp" triggers="2" />

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -21,8 +21,8 @@
 	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:IP Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
-	<!-- TODO: Update "XXX Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:XXX Connection">$CONNECTIONTYPE$</Type>
+	<!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:*** Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "sla")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SLA Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "service")-->

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -16,27 +16,38 @@
 	<!--#if(ConnectionType != SecondConnectionType)-->
 	<!--#if(SecondConnectionType == "http")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:HTTP Connection">$CONNECTIONTYPE$</Type>
-	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+	<!--#elseif(HasSnmpSecondConnection)-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:IP Connection">$CONNECTIONTYPE$</Type>
-	<!--#elseif(SecondConnectionType == "opc")-->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
 	<!-- TODO: Update "XXX Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:XXX Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "sla")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SLA Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "service")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:Service Connection">$CONNECTIONTYPE$</Type>
 	<!--#endif-->
 	<!--#else-->
 	<!--#if(SecondConnectionType == "http")-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:HTTP Connection - XXX">$CONNECTIONTYPE$</Type>
-	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+	<!--#elseif(HasSnmpSecondConnection)-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:IP Connection - XXX">$CONNECTIONTYPE$</Type>
-	<!--#elseif(SecondConnectionType == "opc")-->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+	<!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:*** Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "sla")-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SLA Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "service")-->
+	<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:Service Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#endif-->
 	<!--#endif-->
 	<!--#endif-->
@@ -54,8 +65,8 @@
 			<Type>dummy</Type>
 		</Param>
 	</Params>
+	<!--#if (HasSerialFirstConnection || HasSerialSecondConnection)-->
 
-	<!--#if (ConnectionType == "serial" || SecondConnectionType == "serial")-->
 	<Commands>
 	</Commands>
 	<Responses>
@@ -63,11 +74,12 @@
 	<Pairs>
 	</Pairs>
 	<!--#endif-->
-
 	<!--#if (ConnectionType == "http" || SecondConnectionType == "http")-->
+
 	<HTTP>
 	</HTTP>
 	<!--#endif-->
+
 	<QActions>
 		<QAction id="1" name="Precompiled Code" encoding="csharp" options="precompile" />
 		<QAction id="2" name="After Startup" encoding="csharp" triggers="2" />
@@ -133,9 +145,8 @@
 		</Timer>
 	</Timers>
 
-	<!--#if(SecondConnectionType == "none" || ConnectionType != SecondConnectionType)-->
 	<!--#if(ConnectionType == "virtual")-->
-	<PortSettings name="Virtual Connection">
+	<PortSettings name="Virtual Connection" />
 	<!--#elseif(ConnectionType == "http")-->
 	<PortSettings name="HTTP Connection">
 		<PortTypeUDP>
@@ -144,46 +155,33 @@
 		<PortTypeSerial>
 			<Disabled>true</Disabled>
 		</PortTypeSerial>
-	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
+	</PortSettings>
+	<!--#elseif(HasSnmpFirstConnection)-->
 	<PortSettings name="SNMP Connection">
+		<IPport>
+			<DefaultValue>161</DefaultValue>
+		</IPport>
+	</PortSettings>
 	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
 	<PortSettings name="IP Connection">
 		<PortTypeSerial>
 			<Disabled>true</Disabled>
 		</PortTypeSerial>
-	<!--#elseif(ConnectionType == "opc")-->
-	<PortSettings name="OPC Connection">
-	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
-	<PortSettings name="*** Connection"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
-	<!--#endif-->
-	<!--#else-->
-	<!--#if(ConnectionType == "http")-->
-	<PortSettings name="HTTP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
-		<PortTypeUDP>
-			<Disabled>true</Disabled>
-		</PortTypeUDP>
-		<PortTypeSerial>
-			<Disabled>true</Disabled>
-		</PortTypeSerial>
-	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
-	<PortSettings name="SNMP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
-	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
-	<PortSettings name="IP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
-		<PortTypeSerial>
-			<Disabled>true</Disabled>
-		</PortTypeSerial>
-	<!--#elseif(ConnectionType == "opc")-->
-	<PortSettings name="OPC Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
-	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
-	<PortSettings name="*** Connection - XXX"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.).-->
-	<!--#endif-->
-	<!--#endif-->
 	</PortSettings>
-
+	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
+	<PortSettings name="*** Connection">
+	<!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+	</PortSettings>
+	<!--#elseif(ConnectionType == "sla")-->
+	<PortSettings name="SLA Connection" />
+	<!--#elseif(ConnectionType == "service")-->
+	<PortSettings name="Service Connection" />
+	<!--#endif-->
 	<!--#if(SecondConnectionType != "none")-->
+
 	<Ports>
 	<!--#if(ConnectionType != SecondConnectionType)-->
-	<!--#if(SecondConnectionType == "http")-->
+		<!--#if(SecondConnectionType == "http")-->
 		<PortSettings name="HTTP Connection">
 			<PortTypeUDP>
 				<Disabled>true</Disabled>
@@ -191,41 +189,69 @@
 			<PortTypeSerial>
 				<Disabled>true</Disabled>
 			</PortTypeSerial>
-	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+		</PortSettings>
+		<!--#elseif(HasSnmpSecondConnection)-->
 		<PortSettings name="SNMP Connection">
-	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+			<IPport>
+				<DefaultValue>161</DefaultValue>
+			</IPport>
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
 		<PortSettings name="IP Connection">
 			<PortTypeSerial>
 				<Disabled>true</Disabled>
 			</PortTypeSerial>
-	<!--#elseif(SecondConnectionType == "opc")-->
-		<PortSettings name="OPC Connection">
-	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
-		<PortSettings name="*** Connection"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and update the Protocl/Type@advanced attribute value accordingly. -->
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+		<PortSettings name="*** Connection">
+		<!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "sla")-->
+		<PortSettings name="SLA Connection" />
+		<!--#elseif(SecondConnectionType == "service")-->
+		<PortSettings name="Service Connection" />
+		<!--#endif-->
 	<!--#endif-->
-	<!--#else-->
-	<!--#if(ConnectionType == "http")-->
-		<PortSettings name="HTTP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+	<!--#if(ConnectionType == SecondConnectionType)-->
+		<!--#if(SecondConnectionType == "http")-->
+		<PortSettings name="HTTP Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 			<PortTypeUDP>
 				<Disabled>true</Disabled>
 			</PortTypeUDP>
 			<PortTypeSerial>
 				<Disabled>true</Disabled>
 			</PortTypeSerial>
-	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
-		<PortSettings name="SNMP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
-	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
-		<PortSettings name="IP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+		</PortSettings>
+		<!--#elseif(HasSnmpSecondConnection)-->
+		<PortSettings name="SNMP Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+			<IPport>
+				<DefaultValue>161</DefaultValue>
+			</IPport>
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+		<PortSettings name="IP Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
 			<PortTypeSerial>
 				<Disabled>true</Disabled>
 			</PortTypeSerial>
-	<!--#elseif(ConnectionType == "opc")-->
-		<PortSettings name="OPC Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
-	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
-		<PortSettings name="*** Connection - XXX"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly.-->
-	<!--#endif-->
-	<!--#endif-->
 		</PortSettings>
+		<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+		<PortSettings name="*** Connection - XXX">
+		<!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "sla")-->
+		<PortSettings name="SLA Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		</PortSettings>
+		<!--#elseif(SecondConnectionType == "service")-->
+		<PortSettings name="Service Connection - XXX">
+		<!-- TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		</PortSettings>
+		<!--#endif-->
+	<!--#endif-->
 	</Ports>
 	<!--#endif-->
 

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -10,11 +10,36 @@
 	<DeviceOID>$DEVICEOID$</DeviceOID>
 	<SNMP includepages="true">auto</SNMP>
 	<ElementType>$ELEMENTTYPE$</ElementType>
-  <!--#if (SecondConnectionType == "none")-->
+	<!--#if (SecondConnectionType == "none")-->
 	<Type relativeTimers="true" options=";unicode">$CONNECTIONTYPE$</Type>
-  <!--#else-->
-  <Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$">$CONNECTIONTYPE$</Type>
-  <!--#endif-->
+	<!--#else-->
+	<!--#if(ConnectionType != SecondConnectionType)-->
+	<!--#if(SecondConnectionType == "http")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:HTTP Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:TCP Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "opc")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+	<!-- TODO: Update "XXX Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:XXX Connection">$CONNECTIONTYPE$</Type>
+	<!--#endif-->
+	<!--#else-->
+	<!--#if(SecondConnectionType == "http")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:HTTP Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:TCP Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "opc")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:XXX Connection - XXX">$CONNECTIONTYPE$</Type>
+	<!--#endif-->
+	<!--#endif-->
+	<!--#endif-->
 	<Display defaultPage="General" pageOrder="General"/>
 
 	<Compliancies>
@@ -30,14 +55,20 @@
 		</Param>
 	</Params>
 
-  <!--#if (ConnectionType == "serial" || SecondConnectionType == "serial")-->
-  <Commands>
-  </Commands>
-  <Responses>
-  </Responses>
-  <Pairs>
-  </Pairs>
-  <!--#else-->
+	<!--#if (ConnectionType == "serial" || SecondConnectionType == "serial")-->
+	<Commands>
+	</Commands>
+	<Responses>
+	</Responses>
+	<Pairs>
+	</Pairs>
+	<!--#else-->
+
+	<!--#if (ConnectionType == "http" || SecondConnectionType == "http")-->
+	<HTTP>
+	</HTTP>
+	<!--#else-->
+
   <!--#endif-->
 	<QActions>
 		<QAction id="1" name="Precompiled Code" encoding="csharp" options="precompile" />
@@ -104,8 +135,101 @@
 		</Timer>
 	</Timers>
 
-	<PortSettings>
+	<!--#if(SecondConnectionType == "none" || ConnectionType != SecondConnectionType)-->
+	<!--#if(ConnectionType == "virtual")-->
+	<PortSettings name="Virtual Connection">
+	<!--#elseif(ConnectionType == "http")-->
+	<PortSettings name="HTTP Connection">
+		<PortTypeUDP>
+			<Disabled>true</Disabled>
+		</PortTypeUDP>
+		<PortTypeSerial>
+			<Disabled>true</Disabled>
+		</PortTypeSerial>
+	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
+	<PortSettings name="SNMP Connection">
+	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
+	<PortSettings name="IP Connection">
+		<PortTypeSerial>
+			<Disabled>true</Disabled>
+		</PortTypeSerial>
+	<!--#elseif(ConnectionType == "opc")-->
+	<PortSettings name="OPC Connection">
+	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
+	<PortSettings name="*** Connection"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used). -->
+	<!--#endif-->
+	<!--#else-->
+	<!--#if(ConnectionType == "http")-->
+	<PortSettings name="HTTP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		<PortTypeUDP>
+			<Disabled>true</Disabled>
+		</PortTypeUDP>
+		<PortTypeSerial>
+			<Disabled>true</Disabled>
+		</PortTypeSerial>
+	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
+	<PortSettings name="SNMP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
+	<PortSettings name="IP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+		<PortTypeSerial>
+			<Disabled>true</Disabled>
+		</PortTypeSerial>
+	<!--#elseif(ConnectionType == "opc")-->
+	<PortSettings name="OPC Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.). -->
+	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
+	<PortSettings name="*** Connection - XXX"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.).-->
+	<!--#endif-->
+	<!--#endif-->
 	</PortSettings>
+
+	<!--#if(SecondConnectionType != "none")-->
+	<Ports>
+	<!--#if(ConnectionType != SecondConnectionType)-->
+	<!--#if(SecondConnectionType == "http")-->
+		<PortSettings name="HTTP Connection">
+			<PortTypeUDP>
+				<Disabled>true</Disabled>
+			</PortTypeUDP>
+			<PortTypeSerial>
+				<Disabled>true</Disabled>
+			</PortTypeSerial>
+	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
+		<PortSettings name="SNMP Connection">
+	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
+		<PortSettings name="IP Connection">
+			<PortTypeSerial>
+				<Disabled>true</Disabled>
+			</PortTypeSerial>
+	<!--#elseif(SecondConnectionType == "opc")-->
+		<PortSettings name="OPC Connection">
+	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
+		<PortSettings name="*** Connection"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and update the Protocl/Type@advanced attribute value accordingly. -->
+	<!--#endif-->
+	<!--#else-->
+	<!--#if(ConnectionType == "http")-->
+		<PortSettings name="HTTP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+			<PortTypeUDP>
+				<Disabled>true</Disabled>
+			</PortTypeUDP>
+			<PortTypeSerial>
+				<Disabled>true</Disabled>
+			</PortTypeSerial>
+	<!--#elseif(ConnectionType == "snmp" || ConnectionType == "snmpv2" || ConnectionType == "snmpv3")-->
+		<PortSettings name="SNMP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+	<!--#elseif(ConnectionType == "smart-serial" || ConnectionType == "smart-serial single")-->
+		<PortSettings name="IP Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+			<PortTypeSerial>
+				<Disabled>true</Disabled>
+			</PortTypeSerial>
+	<!--#elseif(ConnectionType == "opc")-->
+		<PortSettings name="OPC Connection - XXX"><!--TODO: Replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly. -->
+	<!--#elseif(ConnectionType == "serial" || ConnectionType == "serial single")-->
+		<PortSettings name="*** Connection - XXX"><!-- TODO: Update "*** Connection" to either "IP Connection" (if TCP or UDP is used) or "Serial Connection" (if a physical serial port is used) and replace XXX with a meaningful description (e.g. Redundant, Backup, Traps, Events, etc.) and update the value of the Protocol/Type@advanced attribute accordingly.-->
+	<!--#endif-->
+	<!--#endif-->
+		</PortSettings>
+	</Ports>
+	<!--#endif-->
 
 	<VersionHistory>
 		<Branches>

--- a/working/templates/connectorsolution/protocol.xml
+++ b/working/templates/connectorsolution/protocol.xml
@@ -19,7 +19,7 @@
 	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:TCP Connection">$CONNECTIONTYPE$</Type>
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:IP Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "opc")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
@@ -32,11 +32,11 @@
 	<!--#elseif(SecondConnectionType == "snmp" || SecondConnectionType == "snmpv2" || SecondConnectionType == "snmpv3")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:SNMP Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "smart-serial" || SecondConnectionType == "smart-serial single")-->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:TCP Connection - XXX">$CONNECTIONTYPE$</Type>
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:IP Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "opc")-->
 	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:OPC Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#elseif(SecondConnectionType == "serial" || SecondConnectionType == "serial single")-->
-	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:XXX Connection - XXX">$CONNECTIONTYPE$</Type>
+	<Type relativeTimers="true" options=";unicode" advanced="$SECONDCONNECTIONTYPE$:*** Connection - XXX">$CONNECTIONTYPE$</Type>
 	<!--#endif-->
 	<!--#endif-->
 	<!--#endif-->
@@ -62,14 +62,12 @@
 	</Responses>
 	<Pairs>
 	</Pairs>
-	<!--#else-->
+	<!--#endif-->
 
 	<!--#if (ConnectionType == "http" || SecondConnectionType == "http")-->
 	<HTTP>
 	</HTTP>
-	<!--#else-->
-
-  <!--#endif-->
+	<!--#endif-->
 	<QActions>
 		<QAction id="1" name="Precompiled Code" encoding="csharp" options="precompile" />
 		<QAction id="2" name="After Startup" encoding="csharp" triggers="2" />


### PR DESCRIPTION
- Added support for specifying second connection.
- Added additional tags (e.g. HTTP or Pairs) depending on which type of selection has been made.
- Connection names are now added (PortSettings@name and Type@advanced) cf. best practices.
- PortSettings are added to exclude soome type of protocols depending on which type of connection was selected (e.g. serial and UDP are disabled when an HTTP connection is selected).
- Template will now open the protocol.xml file with a postaction.