### PR TITLE
Clean up manifest.yml comments and formatting

### DIFF
--- a/working/templates/SharedItems/CatalogInformation/manifest.yml
+++ b/working/templates/SharedItems/CatalogInformation/manifest.yml
@@ -56,7 +56,6 @@ documentation_url:
 
 # [Optional]
 # People who are responsible for this Catalog item. Might be developers, but this is not required.
-# Format: 'name <email> (url)'
 #   The name is required; max 256 characters.
 #   The email and url are optional, and should be in valid email/URL formats.
 owners:
@@ -71,7 +70,6 @@ owners:
 #   Cannot contain newlines.
 #   Cannot contain leading or trailing whitespace characters.
 tags:
-  - 
   - 
 
 # [Optional]


### PR DESCRIPTION
Removed unnecessary comments and cleaned up the owners and tags sections.

similar as [Remove commented formatting instructions in manifest.yml by jarno-lernou-skyline · Pull Request #59 · SkylineCommunications/Skyline.DataMiner.VisualStudioTemplates.Internal](https://github.com/SkylineCommunications/Skyline.DataMiner.VisualStudioTemplates.Internal/pull/59)