### PR TITLE
Add documentation for custom icon integration

### DIFF
--- a/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
+++ b/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
@@ -41,8 +41,6 @@ You can publish your artifact either manually via the Visual Studio IDE or by se
 You can adjust the information displayed in the Catalog by modifying the `README.md`, the `manifest.yml`, or the images in the `CatalogInformation` folder.
 
 To add a custom icon, place an image named `custom-icon` in the `images` folder, using one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
-
- 
 <!--#endif-->
 <!--#if (IsCatalogNoCICD)-->
 

--- a/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
+++ b/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
@@ -37,6 +37,12 @@ Follow the provided **Getting Started** guide in the new project for further ins
 
 This project was created with support for publishing to the DataMiner Catalog.
 You can publish your artifact either manually via the Visual Studio IDE or by setting up a CI/CD workflow.
+
+You can adjust the information displayed in the catalog by modifying the `README.md`, `manifest.yml`, or the images in the `CatalogInformation` folder.
+
+To add a custom icon, place an image in the `images` folder named `custom-icon` with one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
+
+ 
 <!--#endif-->
 <!--#if (IsCatalogNoCICD)-->
 

--- a/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
+++ b/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
@@ -38,7 +38,7 @@ Follow the provided **Getting Started** guide in the new project for further ins
 This project was created with support for publishing to the DataMiner Catalog.
 You can publish your artifact either manually via the Visual Studio IDE or by setting up a CI/CD workflow.
 
-You can adjust the information displayed in the catalog by modifying the `README.md`, `manifest.yml`, or the images in the `CatalogInformation` folder.
+You can adjust the information displayed in the Catalog by modifying the `README.md`, the `manifest.yml`, or the images in the `CatalogInformation` folder.
 
 To add a custom icon, place an image in the `images` folder named `custom-icon` with one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
 

--- a/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
+++ b/working/templates/SharedItems/SkylineDevopsHelp/GettingStarted.md
@@ -40,7 +40,7 @@ You can publish your artifact either manually via the Visual Studio IDE or by se
 
 You can adjust the information displayed in the Catalog by modifying the `README.md`, the `manifest.yml`, or the images in the `CatalogInformation` folder.
 
-To add a custom icon, place an image in the `images` folder named `custom-icon` with one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
+To add a custom icon, place an image named `custom-icon` in the `images` folder, using one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
 
  
 <!--#endif-->

--- a/working/templates/test-package-project/GettingStarted.md
+++ b/working/templates/test-package-project/GettingStarted.md
@@ -104,6 +104,10 @@ Please consider the following options:
 ## Publishing to the Catalog
 
 This project was created with support for publishing to the DataMiner Catalog. You can publish your artifact manually through Visual Studio or by setting up a CI/CD workflow.
+
+You can adjust the information displayed in the Catalog by modifying the `README.md`, the `manifest.yml`, or the images in the `CatalogInformation` folder.
+
+To add a custom icon, place an image named `custom-icon` in the `images` folder, using one of the supported extensions: `.jpg`, `.jpeg`, `.png`, `.bmp`, `.tif`, `.tiff`, or `.webp`.
 <!--#endif-->
 <!--#if (IsCatalogNoCICD)-->
 


### PR DESCRIPTION
This pull request updates the `GettingStarted.md` guide to provide clearer instructions for customizing catalog information and adding a custom icon for your project.

Documentation improvements:

* Added instructions on how to adjust catalog information by editing the `README.md`, `manifest.yml`, and images in the `CatalogInformation` folder.
* Provided guidance for adding a custom icon by placing an appropriately named image in the `images` folder, with details on supported file extensions.