### PR TITLE
Remove SonarCloud requirement from master workflow

### DIFF
--- a/working/templates/SharedItems/.github/workflows/complete.yml
+++ b/working/templates/SharedItems/.github/workflows/complete.yml
@@ -19,10 +19,9 @@ on:
 jobs:
 
   CI:
+    # For more information which inputs and secrets are available, see the documentation of the reusable workflow:
+    # https://docs.dataminer.services/develop/CICD/GitHub/GitHubReusableWorkflows/GitHub_Reusable_Workflows_Master_Workflow.html
     uses: SkylineCommunications/_ReusableWorkflows/.github/workflows/Master Workflow.yml@main
-    with:
-      sonarcloud-project-name: ${{ vars.SONAR_NAME }} # Go to 'https://sonarcloud.io/projects/create' and create a project. Then create a SONAR_NAME variable with the ID of the project as mentioned in the SonarCloud project URL.
-      # solution-filter-name: "MySolutionFilter.slnf"
     secrets:
       DATAMINER_TOKEN: ${{ secrets.DATAMINER_TOKEN }} # The API key: generated in the DCP Admin app (https://admin.dataminer.services/) as authentication for a certain organization.
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }} # The API key for access to SonarCloud.


### PR DESCRIPTION
This pull request makes a minor update to the `complete.yml` workflow file by removing unused input variables and adding a documentation comment to help users find more information about available inputs and secrets.

Workflow configuration cleanup:

* Added a comment with a link to documentation for available inputs and secrets in the reusable workflow, and removed the unused `with` block (including `sonarcloud-project-name` and a commented-out `solution-filter-name`) from the `CI` job in `.github/workflows/complete.yml`.